### PR TITLE
Add Unit Tests to Bring Coverage to 80%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ hs_err_pid*
 ### Eclipse ###
 .project
 .factorypath
+
+### VS Code ###
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+		    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,7 @@
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
+										<includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
-										<includeTestSourceDirectory>true</includeTestSourceDirectory>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>
                 </configuration>

--- a/src/test/java/com/deloitte/elrr/InputSanitizerTest.java
+++ b/src/test/java/com/deloitte/elrr/InputSanitizerTest.java
@@ -1,0 +1,29 @@
+package com.deloitte.elrr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.jupiter.api.Test;
+
+public class InputSanitizerTest {
+
+    @Test
+    public void testInputSanitizerPrivateConstructor() {
+
+        try {
+            // Get the constructor object for InputSanitizer and make it accessible
+            Constructor<InputSanitizer> constructor = InputSanitizer.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            constructor.newInstance();
+        } catch (InvocationTargetException ie) {
+            assertEquals("This is a utility class and cannot be instantiated", ie.getCause().getMessage());
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e.getMessage());
+        }
+
+    }
+
+}

--- a/src/test/java/com/deloitte/elrr/controller/ELRRStageControllerTest.java
+++ b/src/test/java/com/deloitte/elrr/controller/ELRRStageControllerTest.java
@@ -2,7 +2,6 @@ package com.deloitte.elrr.controller;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -200,7 +198,7 @@ class ELRRStageControllerTest {
             assertEquals(null, servletResponse.getErrorMessage());
 
         } catch (IOException e) {
-            fail("Should not have thrown any exception");  
+            fail("Should not have thrown any exception");
         }
 
     }
@@ -213,12 +211,12 @@ class ELRRStageControllerTest {
                 .get("/api/lrsdata?lastReadDate=TEST-TEST-TEST")
                 .accept(MediaType.APPLICATION_JSON).contentType(
                 MediaType.APPLICATION_JSON);
-            
+
             mockMvc.perform(requestBuilder).andExpect(status()
                 .isBadRequest()).andDo(print());
 
         } catch (Exception e) {
-            fail("Should not have thrown any exception");  
+            fail("Should not have thrown any exception");
         }
     }
 

--- a/src/test/java/com/deloitte/elrr/controller/ELRRStageControllerTest.java
+++ b/src/test/java/com/deloitte/elrr/controller/ELRRStageControllerTest.java
@@ -2,6 +2,7 @@ package com.deloitte.elrr.controller;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,8 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -48,6 +51,7 @@ class ELRRStageControllerTest {
     private StatementResult statementResult;
 
     @Test
+    @WithMockUser
     void testlocalData() throws Exception {
 
         try {
@@ -196,9 +200,26 @@ class ELRRStageControllerTest {
             assertEquals(null, servletResponse.getErrorMessage());
 
         } catch (IOException e) {
-            fail("Should not have thrown any exception");
+            fail("Should not have thrown any exception");  
         }
 
+    }
+
+    @Test
+    @WithMockUser
+    void testLocalDataInvalidDate() throws Exception {
+        try {
+            MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/api/lrsdata?lastReadDate=TEST-TEST-TEST")
+                .accept(MediaType.APPLICATION_JSON).contentType(
+                MediaType.APPLICATION_JSON);
+            
+            mockMvc.perform(requestBuilder).andExpect(status()
+                .isBadRequest()).andDo(print());
+
+        } catch (Exception e) {
+            fail("Should not have thrown any exception");  
+        }
     }
 
 }

--- a/src/test/java/com/deloitte/elrr/controller/package-info.java
+++ b/src/test/java/com/deloitte/elrr/controller/package-info.java
@@ -7,7 +7,7 @@
 /**
  * @author mnelakurti
  *
- *         This package info file for package com.deloitte.elrr.util
+ *         This package info file for package com.deloitte.elrr.controller
  *
  */
-package com.deloitte.elrr.util;
+package com.deloitte.elrr.controller;

--- a/src/test/java/com/deloitte/elrr/exception/ELRRExceptionHandlerTest.java
+++ b/src/test/java/com/deloitte/elrr/exception/ELRRExceptionHandlerTest.java
@@ -1,0 +1,46 @@
+package com.deloitte.elrr.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.context.request.WebRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class ELRRExceptionHandlerTest {
+
+    @InjectMocks
+    private ELRRExceptionHandler exHandler;
+
+    @Mock
+    private WebRequest webRequest;
+
+    @Test
+    public void testHandleGenericException() {
+
+        Exception ex = new Exception("Test exception");
+
+        ResponseEntity<Object> res = exHandler.handleGenericException(ex, webRequest);
+
+        assertEquals(HttpStatus.NOT_FOUND, res.getStatusCode());
+
+    }
+
+    @Test
+    public void testHandleHttpRequestMethodNotSupported() {
+
+        HttpRequestMethodNotSupportedException notSupportedEx = new HttpRequestMethodNotSupportedException("GET");
+
+        ResponseEntity<Object> res = exHandler.handleHttpRequestMethodNotSupported(notSupportedEx, null,
+                HttpStatus.METHOD_NOT_ALLOWED, webRequest);
+
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, res.getStatusCode());
+
+    }
+}

--- a/src/test/java/com/deloitte/elrr/exception/package-info.java
+++ b/src/test/java/com/deloitte/elrr/exception/package-info.java
@@ -7,7 +7,7 @@
 /**
  * @author mnelakurti
  *
- *         This package info file for package com.deloitte.elrr.util
+ *         This package info file for package com.deloitte.elrr.exception
  *
  */
-package com.deloitte.elrr.util;
+package com.deloitte.elrr.exception;

--- a/src/test/java/com/deloitte/elrr/package-info.java
+++ b/src/test/java/com/deloitte/elrr/package-info.java
@@ -7,7 +7,7 @@
 /**
  * @author mnelakurti
  *
- *         This package info file for package com.deloitte.elrr.util
+ *         This package info file for package com.deloitte.elrr
  *
  */
-package com.deloitte.elrr.util;
+package com.deloitte.elrr;


### PR DESCRIPTION
Added unit tests for the Controller, Exception Handler, and InputSanitizer.
Updated Checkstyle errors in test files.
Updated .gitignore to include VSCode-specific files
Current overall Jacoco test coverage: 83%