### PR TITLE
Updated Maven Dependencies Security Vulnerabilities Identified by Twistlock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.11</version>
+		<version>3.4.5</version>
 		<relativePath />
 	</parent>
 	<groupId>com.deloitte</groupId>
@@ -24,18 +23,19 @@
 		<sonar.dynamicAnalysis>resuseReports</sonar.dynamicAnalysis>
 		<sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
 		<sona.lauguage>java</sona.lauguage>
-		<spring-security.version>6.2.3</spring-security.version>
+		<tomcat.version>10.1.42</tomcat.version>
+		<spring-security.version>6.2.8</spring-security.version>
 	</properties>
 	<dependencies>
-	    <dependency>
-            <groupId>com.yetanalytics</groupId>
-            <artifactId>xapi-tools</artifactId>
-            <version>0.0.2</version>
-        </dependency>
- 		<dependency>
+		<dependency>
+			<groupId>com.yetanalytics</groupId>
+			<artifactId>xapi-tools</artifactId>
+			<version>0.0.2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.shared</groupId>
 			<artifactId>maven-shared-utils</artifactId>
-			<version>3.3.3</version>
+			<version>3.4.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-io</groupId>
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
-			<version>3.1.6</version>
+			<version>3.4.5</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework</groupId>
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<version>6.0.23</version>
+			<version>6.1.21</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
@@ -103,6 +103,11 @@
 			<groupId>org.zaproxy</groupId>
 			<artifactId>zap</artifactId>
 			<version>2.14.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>10.1.42</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.spacefox</groupId>
@@ -169,7 +174,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-validator</groupId>
@@ -193,6 +198,16 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>6.1.21</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>6.1.21</version>
+		</dependency>
+		<dependency>
 			<groupId>com.github.ulisesbocchio</groupId>
 			<artifactId>jasypt-spring-boot-starter</artifactId>
 			<version>3.0.5</version>
@@ -204,12 +219,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
-			<version>3.1.0</version>
+			<version>3.4.5</version>
 		</dependency>
 		<dependency>
 			<groupId>cn.hutool</groupId>
 			<artifactId>hutool-json</artifactId>
-			<version>5.8.22</version>
+			<version>5.8.25</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.codehaus.plexus</groupId>
@@ -247,7 +262,12 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.74</version>
+			<version>1.78.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>1.78.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -262,23 +282,23 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
-			<version>1.4.14</version>
+			<version>1.5.18</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.4.12</version>
+			<version>1.5.18</version>
 		</dependency>
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-core</artifactId>
 			<version>1.37.0</version>
 		</dependency>
-        <dependency>
-            <groupId>cn.hutool</groupId>
-            <artifactId>hutool-core</artifactId>
-            <version>5.8.25</version>
-        </dependency>
+		<dependency>
+			<groupId>cn.hutool</groupId>
+			<artifactId>hutool-core</artifactId>
+			<version>5.8.25</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -342,27 +362,27 @@
 				<artifactId>jasypt-maven-plugin</artifactId>
 				<version>3.0.5</version>
 			</plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.6.0</version>
-                <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
-                    <encoding>UTF-8</encoding>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>verify</id>
-                        <phase>verify</phase>
-                    <goals>
-                        <goal>check</goal>
-                    </goals>
-                    </execution>
-                </executions>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.6.0</version>
+				<configuration>
+					<configLocation>checkstyle.xml</configLocation>
+					<encoding>UTF-8</encoding>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<linkXRef>false</linkXRef>
+				</configuration>
+				<executions>
+					<execution>
+						<id>verify</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>


### PR DESCRIPTION
Updated 20 Maven dependencies security vulnerabilities identified by Twistlock in the P1 pipeline.  

### **Changes**
1. CVE-2025-22235
    * Package: spring-boot
    * Affected Versions: ['>=3.1.0', '<=3.1.15.2']
    * Upgrade to version 3.4.5 was needed because fixed/patched version 3.1.16 and 3.2.14 are only available with Enterprise Support
    * Updated from 3.1.12 to 3.4.5
2. CVE-2024-38819
    * Package: spring-webmvc
    * Affected Versions: ['>=6.0.0', '<=6.0.23']
    * Upgrade from 6.0.21 to 6.1.21
3. CVE-2024-38816
    * Package: spring-webmvc
    * Affected Versions: ['>=6.0.0', '<=6.0.23']
    * Upgrade from 6.0.21 to 6.1.21
 4. CVE-2025-24813
    * Package: tomcat-embed-core
    * Affected Versions: ['<10.1.35', '>=10.1.1']
    * Updated from 10.1.24 to 10.1.42
5. CVE-2025-31651
    * Package: tomcat-embed-core
    * Affected Versions: ['<10.1.40', '>=10.1.0']
    * Updated from 10.1.24 to 10.1.42
6. CVE-2024-12798
    * Package: ch.qos.logback_logback-core
    * Affected Versions: ['>=1.4.0', '<1.5.13']
    * Updated from 1.4.14 to 1.6.3
7. CVE-2024-38821
    * Package: spring-security-core
    * Affected Versions: ['>=6.2.0', '<6.2.8']
    * Updated from 6.2.4 to 6.2.8
8. CVE-2025-31650 (High)
    * Package: tomcat-embed-core
    * Affected Versions: ['<10.1.40', '>=10.1.10']
    * Updated from 10.1.24 to 10.1.42
9. CVE-2025-48988 
    * Package: tomcat-embed-core
    * Affected Versions: ['>=10.1.0-M1', '<=10.1.41']
    * Updated from 10.1.24 to 10.1.42
10. CVE-2024-38286
    * Package: tomcat-embed-core
    * Affected Versions: ['>=10.1.0-M1', '<=10.1.41']
    * Updated from 10.1.24 to 10.1.42
11. CVE-2024-56337
    * Package: tomcat-embed-core
    * Affected Versions: ['>=10.1.0-M1', '<10.1.34']
    * Updated from 10.1.24 to 10.1.42
12. CVE-2025-49125
    * Package: tomcat-embed-core
    * Affected Versions: ['>=10.1.0-M1', '<=10.1.41']
    * Updated from 10.1.24 to 10.1.42
13. CVE-2024-50379
    * Package: tomcat-embed-core
    * Affected Versions:  ['>=10.1.0-M1', '<10.1.34']
    * Updated from 10.1.24 to 10.1.42
14. CVE-2024-47554
    * Package: commons-io_commons-io
    * Affected Versions: ['>=2.0', '<2.14.0']
    * Updated from 2.8.0 to 2.14.0
15. CVE-2025-41234
    * Package: org.springframework_spring-web
    * Affected Versions: ['>=6.0.5', '<=6.0.23']
    * Updated from 6.0.23 to 6.1.21
16. CVE-2024-38820
    * Package: org.springframework_spring-web
    * Affected Versions: ['>=6.0.5', '<=6.0.23']
    * Updated from 6.0.23 to 6.1.21
17. CVE-2023-33202
    * Package: org.bouncycastle_bcpkix-jdk18on
    * Affected Versions: ['<1.73']
    * Updated from 1.72.0 to 1.78.1
18. CVE-2024-38827
    * Package: spring-security-core
    * Affected Versions: ['>=6.2.0', '<6.2.8']
    * Updated from 6.2.4 to 6.2.8
19. CVE-2024-26308
    * Package: org.apache.commons_commons-compress
    * Affected Versions: ['<1.26.0', '>=1.21']
    * Updated from 1.25.0 to 1.26.0
20. CVE-2024-25710
    * Package: org.apache.commons_commons-compress
    * Affected Versions: ['<1.26.0', '>=1.3’]
    * Updated from 1.25.0 to 1.26.0
