### PR TITLE
Fix p1 dependency-check issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,17 @@
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
 			<version>1.7</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+			<version>1.11.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgraded commons-beanutils from version 1.9.4 (previously included via commons-validator) to 1.11.0 to fix the failing P1 dependency check.
(https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils/1.9.4)